### PR TITLE
Update main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: 3.8
 


### PR DESCRIPTION
In the Annotations to Actions (Build) stated: Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v3. 

So we have python-app.yaml that have the settings with v2 and main.yaml with v2. I think they should be brought to the common denominator.